### PR TITLE
adds PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,29 @@
+# Pull Request Title (e.g., Feature: Add user authentication)
+
+## Description
+Clearly describe the purpose and scope of this pull request. What problem does it solve? What new functionality does it introduce?
+
+## Related Issues
+Link any relevant issues or tasks that this PR addresses.
+Closes #123 (if applicable)
+
+## Changes Made
+Summarize the key changes implemented in this PR.
+- [ ] List of specific changes (e.g., added new endpoint, refactored component X)
+
+## How to Test
+Provide clear instructions on how to test the changes in this PR.
+1. Step 1
+2. Step 2
+
+## Screenshots (if applicable)
+Add screenshots or GIFs to demonstrate visual changes or new features.
+
+## Review Checklist
+- [ ] Code adheres to project coding standards.
+- [ ] All tests (if applicable) pass locally.
+- [ ] Documentation (if applicable) has been updated.
+- [ ] No new warnings or errors introduced.
+
+## Additional Notes
+Any other information that might be helpful for reviewers.


### PR DESCRIPTION
The dev team mentioned creating a PR template. 

I thought it would be good to do that before we start coding. So here's my suggestion. 

I've added a `pull_request_template.md` file to the `docs` folder.

According to the [GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), the template should be visible when a team member makes a PR. 




