### PR TITLE
Feat(server): freelancing applications

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,6 +15,7 @@
     "migrate": "dotenvx run -- node --no-warnings=ExperimentalWarning --loader ts-node/esm src/database/migrate.ts"
   },
   "dependencies": {
+    "@paralleldrive/cuid2": "3.0.4",
     "argon2": "0.44.0",
     "better-auth": "1.4.5",
     "cors": "2.8.5",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,8 +1,9 @@
 import express from "express";
 import cors from "cors";
 import { corsOptions } from "./config/cors.js";
-import healthRouter from "./health/index.js";
 import authRouter from "./auth/index.js";
+import healthRouter from "./health/index.js";
+import jobsRouter from "./jobs/index.js";
 
 const app = express();
 
@@ -16,6 +17,7 @@ app.use(express.json());
 
 app.use("/api/v1", healthRouter);
 app.use("/api/v1/auth", authRouter);
+app.use("/api/v1/jobs", jobsRouter);
 
 app.use((_, res) => {
   res.status(404).send({ message: "route not found" });

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import { corsOptions } from "./config/cors.js";
+import applicationsRouter from "./applications/index.js";
 import authRouter from "./auth/index.js";
 import healthRouter from "./health/index.js";
 import jobsRouter from "./jobs/index.js";
@@ -16,6 +17,7 @@ app.use(cors(corsOptions));
 app.use(express.json());
 
 app.use("/api/v1", healthRouter);
+app.use("/api/v1/applications", applicationsRouter);
 app.use("/api/v1/auth", authRouter);
 app.use("/api/v1/jobs", jobsRouter);
 

--- a/apps/server/src/applications/application-handlers.ts
+++ b/apps/server/src/applications/application-handlers.ts
@@ -108,6 +108,37 @@ export async function createApplication(req: Request, res: Response) {
   }
 }
 
+export async function getPendingApplication(req: Request, res: Response) {
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(req.headers),
+  });
+
+  if (!session) {
+    res.status(401).json({ message: "log in to continue" });
+    return;
+  }
+
+  try {
+    const db = makeDb<{ applications: ApplicationsTable }>();
+    const application = await db
+      .selectFrom("applications")
+      .selectAll()
+      .where("status", "=", "pending")
+      .where("user_id", "=", session.user.id)
+      .executeTakeFirst();
+
+    if (!application) {
+      res.status(404).json({ message: "pending application not found" });
+      return;
+    }
+
+    res.json({ application });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "internal server error" });
+  }
+}
+
 function validateApplicationData(body: unknown) {
   const applicationSchema = z.object({
     // TODO: change relevant properties to enums after seeing frontend

--- a/apps/server/src/applications/application-handlers.ts
+++ b/apps/server/src/applications/application-handlers.ts
@@ -1,0 +1,141 @@
+import type { Request, Response } from "express";
+import type { ColumnType } from "kysely";
+import type { JobsTable } from "../jobs/job-handlers.js";
+import { fromNodeHeaders } from "better-auth/node";
+import z from "zod";
+import { auth } from "../auth/index.js";
+import { makeDb, makeId } from "../database/db.js";
+
+/*
+opted for simpler interface instead of discriminated union
+for status+rejection_reason as a workaround for kysely
+not supporting them, resulting in typing errors when used
+see https://github.com/kysely-org/kysely/issues/577
+*/
+type Status = "pending" | "approved" | "rejected";
+interface ApplicationsTable {
+  id: ColumnType<string, string, never>;
+  user_id: ColumnType<string, string, never>;
+  job_id: JobsTable["id"];
+  experience: string;
+  skills: string;
+  portfolio_url: URL["href"];
+  services_description: string;
+  is_public: boolean;
+  status: ColumnType<
+    Status,
+    Extract<Status, "pending">,
+    Exclude<Status, "pending">
+  >;
+  rejection_reason?: string;
+  created_at: ColumnType<ReturnType<Date["toISOString"]>, never, never>;
+  updated_at: ColumnType<
+    ReturnType<Date["toISOString"]>,
+    never,
+    ReturnType<Date["toISOString"]>
+  >;
+}
+
+export async function createApplication(req: Request, res: Response) {
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(req.headers),
+  });
+
+  if (!session) {
+    res.status(401).json({ message: "log in to continue" });
+    return;
+  }
+
+  const { success, data: validated, error } = validateApplicationData(req.body);
+
+  if (!success) {
+    res.status(422).json({ message: "invalid input", errors: error });
+    return;
+  }
+
+  const normalized = normalizeApplicationData(validated);
+
+  try {
+    const db = makeDb<{ applications: ApplicationsTable; jobs: JobsTable }>();
+
+    const job = await db
+      .selectFrom("jobs")
+      .selectAll()
+      .where("jobs.id", "=", normalized.jobId)
+      .executeTakeFirst();
+
+    if (!job) {
+      res.status(422).json({ message: "invalid job" });
+      return;
+    }
+
+    const hasPendingApplications = await db
+      .selectFrom("applications")
+      .innerJoin("jobs", "jobs.id", "applications.job_id")
+      .select("applications.id as id")
+      .where("status", "=", "pending")
+      .where("user_id", "=", session.user.id)
+      .where("job_id", "=", job.id)
+      .executeTakeFirst();
+
+    if (hasPendingApplications) {
+      res
+        .status(403)
+        .json({ message: "a previous application is pending review" });
+      return;
+    }
+
+    const application = await db
+      .insertInto("applications")
+      .values({
+        id: makeId(),
+        user_id: session.user.id,
+        job_id: job.id,
+        experience: normalized.experience,
+        skills: normalized.skills,
+        portfolio_url: normalized.portfolioUrl,
+        services_description: normalized.servicesDescription,
+        is_public: normalized.isPublic,
+        status: "pending",
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    res.status(201).json({ application });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "internal server error" });
+  }
+}
+
+function validateApplicationData(body: unknown) {
+  const applicationSchema = z.object({
+    // TODO: change relevant properties to enums after seeing frontend
+    jobId: z.string().trim().nonempty(),
+    experience: z.string(),
+    skills: z.string().nonempty(),
+    portfolioUrl: z.url(),
+    servicesDescription: z.string().trim().nonempty(),
+    isPublic: z.boolean().optional(),
+  });
+
+  const { success, data, error } = applicationSchema.safeParse(body);
+  if (success) {
+    return { success, data };
+  }
+
+  return { success, error: z.flattenError(error) };
+}
+
+function normalizeApplicationData(
+  validated: NonNullable<ReturnType<typeof validateApplicationData>["data"]>,
+) {
+  return {
+    jobId: validated.jobId.trim(),
+    experience: validated.experience.trim().toLowerCase(),
+    skills: validated.skills.trim().toLowerCase(),
+    portfolioUrl: new URL(validated.portfolioUrl).href,
+    servicesDescription: validated.servicesDescription.trim(),
+    isPublic: validated.isPublic ?? true,
+  };
+}

--- a/apps/server/src/applications/index.ts
+++ b/apps/server/src/applications/index.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { createApplication } from "./application-handlers.js";
+
+const applicationsRouter = Router();
+applicationsRouter.post("/", createApplication);
+
+export default applicationsRouter;

--- a/apps/server/src/applications/index.ts
+++ b/apps/server/src/applications/index.ts
@@ -1,7 +1,11 @@
 import { Router } from "express";
-import { createApplication } from "./application-handlers.js";
+import {
+  createApplication,
+  getPendingApplication,
+} from "./application-handlers.js";
 
 const applicationsRouter = Router();
 applicationsRouter.post("/", createApplication);
+applicationsRouter.get("/current", getPendingApplication);
 
 export default applicationsRouter;

--- a/apps/server/src/auth/index.ts
+++ b/apps/server/src/auth/index.ts
@@ -4,7 +4,7 @@ import { fromNodeHeaders } from "better-auth/node";
 import { Router } from "express";
 import z from "zod";
 import { ENV } from "../config/env.js";
-import { makeDb } from "../database/db.js";
+import { makeDb, makeId } from "../database/db.js";
 
 interface BetterAuthTablesConfig {
   user: BetterAuthOptions["user"];
@@ -71,6 +71,11 @@ const auth = betterAuth<BetterAuthOptions>({
     */
     casing: "snake",
     transaction: true,
+  },
+  advanced: {
+    database: {
+      generateId: () => makeId(),
+    },
   },
   ...authTablesConfig,
   emailAndPassword: {

--- a/apps/server/src/auth/index.ts
+++ b/apps/server/src/auth/index.ts
@@ -58,7 +58,7 @@ const authTablesConfig: BetterAuthTablesConfig = {
   },
 };
 
-const auth = betterAuth<BetterAuthOptions>({
+export const auth = betterAuth<BetterAuthOptions>({
   baseURL: ENV.server.ORIGIN,
   secret: ENV.auth.PASSWORD_PEPPER,
   database: {

--- a/apps/server/src/database/db.ts
+++ b/apps/server/src/database/db.ts
@@ -1,6 +1,7 @@
 import { Pool } from "pg";
 import { Kysely, PostgresDialect, sql } from "kysely";
 import { ENV } from "../config/env.js";
+import { createId, isCuid } from "@paralleldrive/cuid2";
 
 let db: Kysely<object>;
 
@@ -40,4 +41,12 @@ export async function pingDb() {
     console.error("> DB ping failed", err);
     return false;
   }
+}
+
+export function makeId() {
+  return createId();
+}
+
+export function isValidId(id: string) {
+  return isCuid(id);
 }

--- a/apps/server/src/database/migrations/2025-12-07T15-50-21.596Z-create-auth-tables.ts
+++ b/apps/server/src/database/migrations/2025-12-07T15-50-21.596Z-create-auth-tables.ts
@@ -1,4 +1,4 @@
-import { Kysely, sql } from "kysely";
+import { sql, type Kysely } from "kysely";
 
 export async function up({ schema }: Kysely<unknown>) {
   await schema
@@ -15,6 +15,7 @@ export async function up({ schema }: Kysely<unknown>) {
       col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull(),
     )
     .execute();
+
   await schema
     .createTable("sessions")
     .addColumn("id", "text", (col) => col.primaryKey())
@@ -32,6 +33,7 @@ export async function up({ schema }: Kysely<unknown>) {
       col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull(),
     )
     .execute();
+
   await schema
     .createTable("accounts")
     .addColumn("id", "text", (col) => col.primaryKey())
@@ -54,6 +56,7 @@ export async function up({ schema }: Kysely<unknown>) {
       col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
     )
     .execute();
+
   await schema
     .createTable("verifications")
     .addColumn("id", "text", (col) => col.primaryKey())
@@ -67,6 +70,7 @@ export async function up({ schema }: Kysely<unknown>) {
       col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
     )
     .execute();
+
   await schema
     .createIndex("sessions_user_id_idx")
     .on("sessions")

--- a/apps/server/src/database/migrations/2025-12-09T10-10-16.329Z-create-application-tables.ts
+++ b/apps/server/src/database/migrations/2025-12-09T10-10-16.329Z-create-application-tables.ts
@@ -1,0 +1,86 @@
+import { sql, type Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>) {
+  await db.schema
+    .createType("application_status")
+    .asEnum(["pending", "approved", "rejected"])
+    .execute();
+
+  await db.schema
+    .createTable("jobs")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("name", "text", (col) => col.notNull().unique())
+    .addColumn("slug", "text", (col) => col.notNull().unique())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createTable("applications")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("user_id", "text", (col) =>
+      col.notNull().references("users.id").onDelete("cascade"),
+    )
+    .addColumn("job_id", "text", (col) =>
+      col.notNull().references("jobs.id").onDelete("restrict"),
+    )
+    .addColumn("experience", "text", (col) => col.notNull())
+    .addColumn("skills", "text", (col) => col.notNull())
+    .addColumn("portfolio_url", "text", (col) => col.notNull())
+    .addColumn("services_description", "text", (col) => col.notNull())
+    .addColumn("is_public", "boolean", (col) => col.notNull())
+    .addColumn("status", sql`application_status`, (col) =>
+      col.defaultTo("pending").notNull(),
+    )
+    .addColumn("rejection_reason", "text")
+    .addCheckConstraint(
+      "rejection_reason_required_if_rejected",
+      sql`status <> 'rejected' OR rejection_reason IS NOT NULL`,
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("jobs_job_slug_idx")
+    .on("jobs")
+    .column("slug")
+    .execute();
+
+  await db.schema
+    .createIndex("applications_user_id_idx")
+    .on("applications")
+    .column("user_id")
+    .execute();
+
+  await db.schema
+    .createIndex("applications_job_id_idx")
+    .on("applications")
+    .column("job_id")
+    .execute();
+
+  await db.schema
+    .createIndex("applications_user_id_job_id_idx")
+    .on("applications")
+    .columns(["user_id", "job_id"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>) {
+  await db.schema.dropIndex("applications_user_id_job_id_idx").execute();
+  await db.schema.dropIndex("applications_job_id_idx").execute();
+  await db.schema.dropIndex("applications_user_id_idx").execute();
+  await db.schema.dropIndex("jobs_job_slug_idx").execute();
+
+  await db.schema.dropTable("applications").ifExists().execute();
+  await db.schema.dropTable("jobs").ifExists().execute();
+  await db.schema.dropType("application_status").ifExists().execute();
+}

--- a/apps/server/src/jobs/index.ts
+++ b/apps/server/src/jobs/index.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { getJobs } from "./job-handlers.js";
+
+const jobsRouter = Router();
+jobsRouter.get("/", getJobs);
+
+export default jobsRouter;

--- a/apps/server/src/jobs/job-handlers.ts
+++ b/apps/server/src/jobs/job-handlers.ts
@@ -1,0 +1,32 @@
+import type { Request, Response } from "express";
+import type { ColumnType } from "kysely";
+import { fromNodeHeaders } from "better-auth/node";
+import { auth } from "../auth/index.js";
+import { makeDb } from "../database/db.js";
+
+interface JobsTable {
+  id: ColumnType<string, string, never>;
+  name: string;
+  slug: string;
+}
+
+export async function getJobs(req: Request, res: Response) {
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(req.headers),
+  });
+
+  if (!session) {
+    res.status(401).json({ message: "log in to continue" });
+    return;
+  }
+
+  try {
+    const db = makeDb<{ jobs: JobsTable }>();
+    const jobs = await db.selectFrom("jobs").selectAll().execute();
+
+    res.json({ jobs });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "internal server error" });
+  }
+}

--- a/apps/server/src/jobs/job-handlers.ts
+++ b/apps/server/src/jobs/job-handlers.ts
@@ -4,7 +4,7 @@ import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "../auth/index.js";
 import { makeDb } from "../database/db.js";
 
-interface JobsTable {
+export interface JobsTable {
   id: ColumnType<string, string, never>;
   name: string;
   slug: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       "name": "@worksy/server",
       "version": "1.0.0",
       "dependencies": {
+        "@paralleldrive/cuid2": "3.0.4",
         "argon2": "0.44.0",
         "better-auth": "1.4.5",
         "cors": "2.8.5",
@@ -1524,6 +1525,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-3.0.4.tgz",
+      "integrity": "sha512-sM6M2PWrByOEpN2QYAdulhEbSZmChwj0e52u4hpwB7u4PznFiNAavtE6m7O8tWUlzX+jT2eKKtc5/ZgX+IHrtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "bignumber.js": "^9.3.1",
+        "error-causes": "^3.0.2"
+      },
+      "bin": {
+        "cuid2": "bin/cuid2.js"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@phc/format": {
@@ -3009,6 +3036,15 @@
         }
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3584,6 +3620,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/error-causes": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/error-causes/-/error-causes-3.0.2.tgz",
+      "integrity": "sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",


### PR DESCRIPTION
# Feat(server): freelancing applications

Closes [WRKSY-51](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-51).
This PR adds support for creating new freelancer applications, as well as getting a list of jobs for various frontend filters and dropdowns

## Related Issues

See [WRKSY-45](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-45).

## Changes Made

- added `GET /api/v1/jobs` to fetch all available jobs
- added `POST /api/v1/applications` to apply for a freelancer under a job title
- added migration to set up user jobs and applications tables

## How to Test

- test locally:
   1. run the migration on an empty or non conflicting db
   2. create a new job using your db GUI
   3. go through the authentication flow (sign-up or sign-in) to get a session cookie
   4. go through the application creation flow
- check the preview deploy for errors

## Review Checklist

- [x] [WRKSY-51](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-51)'s technical requirements are implemented
- [x] relevant acceptance criteria from [WRKSY-45](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-45) are met
- [x] solution adheres to our [Definition of Done](https://github.com/chingu-voyages/V58-tier3-team-33/wiki/Definition-of-Done)
- [x] documentation (if applicable) has been updated
- [x] no new warnings or errors introduced
