### PR TITLE
Feat(server): freelancer job profile

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import { corsOptions } from "./config/cors.js";
 import applicationsRouter from "./applications/index.js";
 import authRouter from "./auth/index.js";
+import freelancersRouter from "./freelancers/index.js";
 import healthRouter from "./health/index.js";
 import jobsRouter from "./jobs/index.js";
 
@@ -19,6 +20,7 @@ app.use(express.json());
 app.use("/api/v1", healthRouter);
 app.use("/api/v1/applications", applicationsRouter);
 app.use("/api/v1/auth", authRouter);
+app.use("/api/v1/freelancers", freelancersRouter);
 app.use("/api/v1/jobs", jobsRouter);
 
 app.use((_, res) => {

--- a/apps/server/src/applications/application-handlers.ts
+++ b/apps/server/src/applications/application-handlers.ts
@@ -13,7 +13,7 @@ not supporting them, resulting in typing errors when used
 see https://github.com/kysely-org/kysely/issues/577
 */
 type Status = "pending" | "approved" | "rejected";
-interface ApplicationsTable {
+export interface ApplicationsTable {
   id: ColumnType<string, string, never>;
   user_id: ColumnType<string, string, never>;
   job_id: JobsTable["id"];

--- a/apps/server/src/freelancers/freelancer-handlers.ts
+++ b/apps/server/src/freelancers/freelancer-handlers.ts
@@ -1,0 +1,83 @@
+import type { Request, Response } from "express";
+import type { ApplicationsTable } from "../applications/application-handlers.js";
+import type { JobsTable } from "../jobs/job-handlers.js";
+import { fromNodeHeaders } from "better-auth/node";
+import { auth } from "../auth/index.js";
+import { isValidId, makeDb } from "../database/db.js";
+
+export async function getFreelancerProfile(req: Request, res: Response) {
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(req.headers),
+  });
+
+  if (!session) {
+    res.status(401).json({ message: "log in to continue" });
+    return;
+  }
+
+  const { path } = req.params;
+
+  if (!path) {
+    res.status(422).json({ message: "invalid id" });
+    return;
+  }
+
+  // assumes id does not contain "-".
+  // should always be the case if we're using cuid2
+  const splitIdx = path.indexOf("-");
+  const userId = path.slice(0, splitIdx);
+  const jobSlug = path.slice(splitIdx + 1);
+
+  if (
+    typeof userId != "string" ||
+    !isValidId(userId) ||
+    typeof jobSlug != "string" ||
+    jobSlug.trim().length === 0
+  ) {
+    res.status(422).json({ message: "invalid id" });
+    return;
+  }
+
+  const normalized = {
+    userId: userId.trim(),
+    jobSlug: jobSlug.trim().toLowerCase(),
+  };
+
+  try {
+    const db = makeDb<{ applications: ApplicationsTable; jobs: JobsTable }>();
+
+    const job = await db
+      .selectFrom("jobs")
+      .selectAll()
+      .where("jobs.slug", "=", normalized.jobSlug)
+      .executeTakeFirst();
+
+    if (!job) {
+      res.status(422).json({ message: "invalid job" });
+      return;
+    }
+
+    const freelancerProfile = await db
+      .selectFrom("applications")
+      .innerJoin("jobs", "jobs.id", "applications.job_id")
+      .selectAll("applications")
+      .select(["jobs.name as job_name", "jobs.slug as job_slug"])
+      .where("status", "=", "approved")
+      .where("user_id", "=", normalized.userId)
+      .where("job_id", "=", job.id)
+      .orderBy("applications.updated_at", "desc")
+      .executeTakeFirst();
+
+    if (!freelancerProfile) {
+      res
+        .status(404)
+        .json({ message: "freelancer approved profile not found" });
+      return;
+    }
+
+    res.json({ freelancerProfile });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "internal server error" });
+  }
+}

--- a/apps/server/src/freelancers/index.ts
+++ b/apps/server/src/freelancers/index.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { getFreelancerProfile } from "./freelancer-handlers.js";
+
+const freelancersRouter = Router();
+freelancersRouter.get("/:path", getFreelancerProfile);
+
+export default freelancersRouter;


### PR DESCRIPTION
# Feat(server): freelancer job profile

Closes [WRKSY-58](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-58).
This PR adds support for getting a freelancer's job profile using their id and the associated job's slug.

## Related Issues

See [WRKSY-48](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-48).

## Changes Made

- added `GET /api/v1/freelancers/:path` to fetch job profile data

## How to Test

- test locally:
   1. if necessary, create a new job using your db GUI
   2. go through the authentication flow (sign-up or sign-in) to get a session cookie
   3. go through the application creation flow, and save the application's user id
   4. edit the application from "pending" to "approved" using your db GUI, after querying for applications by user_id
   5. hit `GET api/v1/freelancers/<user_id>-<job_slug>`
- check the preview deploy for errors

## Review Checklist

- [x] [WRKSY-58](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-58)'s technical requirements are implemented
- [x] relevant acceptance criteria from [WRKSY-48](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-48) are met
- [x] solution adheres to our [Definition of Done](https://github.com/chingu-voyages/V58-tier3-team-33/wiki/Definition-of-Done)
- [x] documentation (if applicable) has been updated
- [x] no new warnings or errors introduced
