### PR TITLE
feat(server): list freelancers, optionally by job

### DIFF
--- a/apps/server/src/freelancers/freelancer-handlers.ts
+++ b/apps/server/src/freelancers/freelancer-handlers.ts
@@ -5,6 +5,67 @@ import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "../auth/index.js";
 import { isValidId, makeDb } from "../database/db.js";
 
+export async function getFreelancers(req: Request, res: Response) {
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(req.headers),
+  });
+
+  if (!session) {
+    res.status(401).json({ message: "log in to continue" });
+    return;
+  }
+
+  const { job: slug } = req.query;
+
+  if (slug && typeof slug != "string") {
+    res.status(422).json({ message: "invalid slug" });
+    return;
+  }
+
+  const normalized = {
+    slug: slug?.trim().toLowerCase(),
+  };
+
+  try {
+    const db = makeDb<{ applications: ApplicationsTable; jobs: JobsTable }>();
+
+    let job;
+    if (normalized.slug) {
+      job = await db
+        .selectFrom("jobs")
+        .selectAll()
+        .where("jobs.slug", "=", normalized.slug)
+        .executeTakeFirst();
+      if (!job) {
+        res.status(422).json({ message: "invalid job" });
+        return;
+      }
+    }
+
+    let freelancersQuery = db
+      .selectFrom("applications")
+      .innerJoin("jobs", "jobs.id", "applications.job_id")
+      .selectAll("applications")
+      .select(["jobs.name as job_name", "jobs.slug as job_slug"])
+      .where("status", "=", "approved");
+
+    if (job) {
+      freelancersQuery = freelancersQuery.where("job_id", "=", job.id);
+    }
+
+    const freelancers = await freelancersQuery.execute();
+    if (!freelancers) {
+      res.status(404).json({ message: "freelancers not found" });
+      return;
+    }
+
+    res.json({ freelancers });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "internal server error" });
+  }
+}
+
 export async function getFreelancerProfile(req: Request, res: Response) {
   const session = await auth.api.getSession({
     headers: fromNodeHeaders(req.headers),

--- a/apps/server/src/freelancers/index.ts
+++ b/apps/server/src/freelancers/index.ts
@@ -1,7 +1,8 @@
 import { Router } from "express";
-import { getFreelancerProfile } from "./freelancer-handlers.js";
+import { getFreelancerProfile, getFreelancers } from "./freelancer-handlers.js";
 
 const freelancersRouter = Router();
+freelancersRouter.get("/", getFreelancers);
 freelancersRouter.get("/:path", getFreelancerProfile);
 
 export default freelancersRouter;


### PR DESCRIPTION
# Feat(server): list freelancers, optionally by job

Closes [WRKSY-61](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-61).
This PR adds support for getting a list of freelancers, optionally filtering according to a job.

## Related Issues

See [WRKSY-14](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-14).

## Changes Made

- added `GET /api/v1/freelancers[?job=<value>]` to fetch a list o freelancers

## How to Test

- test locally:
   1. create a couple of applications with different jobs
   2. edit the applications from "pending" to "approved" using your db GUI,
   3. hit `GET api/v1/freelancers/<user_id>-<job_slug>`
- check the preview deploy for errors

## Review Checklist

- [x] [WRKSY-61](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-61)'s technical requirements are implemented
- [x] relevant acceptance criteria from [WRKSY-14](https://v58-tier3-team-33.atlassian.net/browse/WRKSY-14) are met
- [x] solution adheres to our [Definition of Done](https://github.com/chingu-voyages/V58-tier3-team-33/wiki/Definition-of-Done)
- [x] documentation (if applicable) has been updated
- [x] no new warnings or errors introduced
